### PR TITLE
Éco-conception : utilisation du tag <picture> pour les images

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -433,7 +433,7 @@ WAGTAILMENUS_MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN = False
 WAGTAILDOCS_MAX_UPLOAD_SIZE = int(os.getenv("WAGTAILDOCS_MAX_UPLOAD_SIZE", 10 * 1024 * 1024))  # 10MB
 
 WAGTAILIMAGES_IMAGE_MODEL = "sites_conformes_customimages.CustomImage"
-WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg"]
+WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg", "avif"]
 SF_SCHEME_DEPENDENT_SVGS = True if os.getenv("SF_SCHEME_DEPENDENT_SVGS", False) in ["1", "True"] else False
 
 # Allows for complex Streamfields without completely removing checks

--- a/justfile
+++ b/justfile
@@ -111,10 +111,13 @@ web-prompt:
 #### Production-related recipes
 
 # Commands run by the Scalingo Procfile
+# TODO: remove fix_svg_image_extensions once https://github.com/numerique-gouv/sites-faciles/pull/441
+# has been merged and deployed on all Sites Conformes instances
 [group('Production')]
 scalingo-postdeploy:
     python manage.py migrate_from_sites_faciles --no-input
     python manage.py migrate
+    python manage.py fix_svg_images_extensions
     python manage.py create_starter_pages
     python manage.py import_page_templates
     python manage.py update_index

--- a/sites_conformes/blog/templates/sites_conformes_blog/blocks/contact_card.html
+++ b/sites_conformes/blog/templates/sites_conformes_blog/blocks/contact_card.html
@@ -18,12 +18,7 @@
       {% if value.image %}
         <div class="cmsfr-author_card__header fr-card__header">
           <div class="fr-card__img">
-            {% image value.image fill-200x200 as contact_image %}
-            <img class="fr-responsive-img cmsfr-author-img"
-                 src="{{ contact_image.url }}"
-                 width="4.5em"
-                 height="4.5em"
-                 alt="{{ contact_image.alt }}" />
+            {% picture value.image fill-200x200 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img cmsfr-author-img" alt="" width="4.5em" height="4.5em" %}
           </div>
         </div>
       {% endif %}

--- a/sites_conformes/core/management/commands/create_demo_pages.py
+++ b/sites_conformes/core/management/commands/create_demo_pages.py
@@ -17,7 +17,7 @@ from sites_conformes.core.services.accessors import (
 from sites_conformes.core.utils import get_default_site, import_image
 from sites_conformes.forms.models import FormField, FormPage
 
-ALL_ALLOWED_SLUGS = ["blog_index", "publications", "menu_page", "form", "common_blocks", "hero_blocks"]
+ALL_ALLOWED_SLUGS = ["blog_index", "publications", "menu_page", "form", "common_blocks", "hero_blocks", "image_examples"]
 
 fake = Faker("fr_FR")
 
@@ -87,6 +87,8 @@ class Command(BaseCommand):
                 menu_page = ContentPage.objects.get(slug="menu_page", locale=locale)
                 self.create_hero_blocks_page(home_page=home_page, parent_page=menu_page)
 
+            elif slug == "image_examples":
+                self.create_image_examples_page(parent_page=home_page)
             else:
                 raise ValueError(f"Valeur inconnue : {slug}")
 
@@ -314,6 +316,47 @@ class Command(BaseCommand):
             FormField.objects.create(**field_data)
 
         self.stdout.write(self.style.SUCCESS(f"Page {slug} created with id {form_page.id}"))
+
+    def create_image_examples_page(self, parent_page: ContentPage) -> None:
+        """
+        Creates a page showcasing the available illustration images.
+        """
+        slug = "image_examples"
+        already_exists = ContentPage.objects.filter(slug=slug).first()
+        if already_exists:
+            self.stdout.write(f"The page seem to already exist with id {already_exists.id}")
+            return
+
+        illustrations_dir = os.path.join(settings.BASE_DIR, "static", "illustration")
+        image_files = [
+            ("Placeholder-Sites-Faciles.png", "Placeholder Sites Faciles"),
+            ("illustration-sites-faciles-homme-nuages.png", "Illustration Sites Faciles - Homme et nuages"),
+            ("illustration-sites-faciles-femme-ordinateur.png", "Illustration Sites Faciles - Femme à l'ordinateur"),
+        ]
+
+        body = []
+        body.append(("paragraph", RichText("<p>Exemples d'images disponibles dans le projet.</p>")))
+
+        for filename, title in image_files:
+            full_path = os.path.join(illustrations_dir, filename)
+            if not os.path.exists(full_path):
+                self.stdout.write(self.style.WARNING(f"Image not found, skipping: {full_path}"))
+                continue
+
+            image = import_image(full_path, title)
+            body.append(
+                (
+                    "image",
+                    {
+                        "image": image,
+                        "alt": title,
+                        "width": "",
+                    },
+                )
+            )
+
+        get_or_create_content_page(slug, title="Exemples d'images", body=body, parent_page=parent_page)
+        self.stdout.write(self.style.SUCCESS("Image examples page created"))
 
     def create_common_blocks_page(self, parent_page: ContentPage) -> None:
         """

--- a/sites_conformes/core/management/commands/create_demo_pages.py
+++ b/sites_conformes/core/management/commands/create_demo_pages.py
@@ -17,7 +17,15 @@ from sites_conformes.core.services.accessors import (
 from sites_conformes.core.utils import get_default_site, import_image
 from sites_conformes.forms.models import FormField, FormPage
 
-ALL_ALLOWED_SLUGS = ["blog_index", "publications", "menu_page", "form", "common_blocks", "hero_blocks", "image_examples"]
+ALL_ALLOWED_SLUGS = [
+    "blog_index",
+    "publications",
+    "menu_page",
+    "form",
+    "common_blocks",
+    "hero_blocks",
+    "image_examples",
+]
 
 fake = Faker("fr_FR")
 

--- a/sites_conformes/core/management/commands/fix_svg_images_extensions.py
+++ b/sites_conformes/core/management/commands/fix_svg_images_extensions.py
@@ -1,0 +1,44 @@
+from django.core.files.base import ContentFile
+from django.core.management.base import BaseCommand
+from wagtail.images import get_image_model
+from willow.image import (
+    SvgImageFile,
+)
+
+
+def rename_wagtail_image(image, new_filename):
+    old_file = image.file
+    old_file.open()
+
+    content = old_file.read()
+
+    image.file.save(new_filename, ContentFile(content), save=False)
+    old_file.storage.delete(old_file.name)
+
+    # Update only file field prevents erroring on width / height
+    # fields that needs to be calculated for non-svg files
+    image.save(update_fields=["file"])
+
+
+class Command(BaseCommand):
+    help = """
+    Fix all svg images extensions to prevent images with no extensions to make
+    wagtail rendition generation to choke when using picture tag
+
+    See https://github.com/wagtail/wagtail/blob/f96b1fb829b107d1f90bcc6fee2fbf8c9d82263f/wagtail/images/models.py#L902
+    is_svg is called during this process and won't work with images without extension.
+
+    This script is inspired by https://github.com/wagtail/wagtail/blob/f96b1fb829b107d1f90bcc6fee2fbf8c9d82263f/wagtail/images/tests/tests.py#L388C1-L388C51 
+    """
+
+    def handle(self, *args, **kwargs):
+        for image in get_image_model().objects.all():
+            if not image.is_svg():
+                with image.get_willow_image() as willow_image:
+                    if isinstance(willow_image, SvgImageFile):
+                        print(f"Updating {image=}")
+                        print(f"Before: {image.file.name}")
+                        filename = f"{image.file.name}.svg"
+                        print(f"After: {filename}")
+
+                        rename_wagtail_image(image, filename)

--- a/sites_conformes/core/management/commands/fix_svg_images_extensions.py
+++ b/sites_conformes/core/management/commands/fix_svg_images_extensions.py
@@ -31,7 +31,15 @@ class Command(BaseCommand):
     This script is inspired by https://github.com/wagtail/wagtail/blob/f96b1fb829b107d1f90bcc6fee2fbf8c9d82263f/wagtail/images/tests/tests.py#L388C1-L388C51 
     """
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview changes without applying them.",
+        )
+
     def handle(self, *args, **kwargs):
+        dry_run = kwargs["dry_run"]
         for image in get_image_model().objects.all():
             if not image.is_svg():
                 with image.get_willow_image() as willow_image:
@@ -41,4 +49,5 @@ class Command(BaseCommand):
                         filename = f"{image.file.name}.svg"
                         print(f"After: {filename}")
 
-                        rename_wagtail_image(image, filename)
+                        if not dry_run:
+                            rename_wagtail_image(image, filename)

--- a/sites_conformes/core/management/commands/fix_svg_images_extensions.py
+++ b/sites_conformes/core/management/commands/fix_svg_images_extensions.py
@@ -8,12 +8,22 @@ from willow.image import (
 
 def rename_wagtail_image(image, new_filename):
     old_file = image.file
-    old_file.open()
+    # Capture the original name and storage as plain values before saving:
+    # image.file.save() mutates image.file (and therefore old_file, which is
+    # the same FieldFile object) to point at the new name, so reading
+    # old_file.name afterwards would yield the new name and delete the file we
+    # just created.
+    old_name = old_file.name
+    old_storage = old_file.storage
 
-    content = old_file.read()
+    old_file.open()
+    try:
+        content = old_file.read()
+    finally:
+        old_file.close()
 
     image.file.save(new_filename, ContentFile(content), save=False)
-    old_file.storage.delete(old_file.name)
+    old_storage.delete(old_name)
 
     # Update only file field prevents erroring on width / height
     # fields that needs to be calculated for non-svg files

--- a/sites_conformes/core/page_templates/img/image_data.json
+++ b/sites_conformes/core/page_templates/img/image_data.json
@@ -30,7 +30,7 @@
       ]
     },
     "title": "Pictogrammes DSFR \u2014 Leisure \u2014 Digital Art",
-    "filename": "Pictogrammes DSFR \u2014 Leisure \u2014 Digital Art",
+    "filename": "Pictogrammes DSFR \u2014 Leisure \u2014 Digital Art.svg",
     "is_pictogram": true
   },
   "6": {
@@ -54,7 +54,7 @@
       ]
     },
     "title": "Pictogrammes DSFR \u2014 System \u2014 Information",
-    "filename": "Pictogrammes DSFR \u2014 System \u2014 Information",
+    "filename": "Pictogrammes DSFR \u2014 System \u2014 Information.svg",
     "is_pictogram": true
   },
   "77": {
@@ -68,7 +68,7 @@
       ]
     },
     "title": "Pictogrammes DSFR \u2014 System \u2014 Success",
-    "filename": "Pictogrammes DSFR \u2014 System \u2014 Success",
+    "filename": "Pictogrammes DSFR \u2014 System \u2014 Success.svg",
     "is_pictogram": true
   },
   "78": {
@@ -82,7 +82,7 @@
       ]
     },
     "title": "Pictogrammes DSFR \u2014 System \u2014 System",
-    "filename": "Pictogrammes DSFR \u2014 System \u2014 System",
+    "filename": "Pictogrammes DSFR \u2014 System \u2014 System.svg",
     "is_pictogram": true
   },
   "112": {
@@ -156,7 +156,7 @@
       ]
     },
     "title": "Pictogrammes DSFR \u2014 Digital \u2014 Avatar",
-    "filename": "Pictogrammes DSFR \u2014 Digital \u2014 Avatar",
+    "filename": "Pictogrammes DSFR \u2014 Digital \u2014 Avatar.svg",
     "is_pictogram": true
   },
   "163": {

--- a/sites_conformes/core/services/import_export.py
+++ b/sites_conformes/core/services/import_export.py
@@ -1,9 +1,8 @@
 import copy
 import json
-import os
 import sys
 from io import BytesIO
-from pathlib import PosixPath
+from pathlib import Path
 from urllib.request import urlretrieve
 
 import requests
@@ -18,6 +17,7 @@ from wagtail.utils.file import hash_filelike
 from sites_conformes.core.constants import HEADER_FIELDS
 from sites_conformes.core.models import ContentPage
 from sites_conformes.core.services.accessors import get_or_create_collection, get_or_create_content_page
+from sites_conformes.core.utils import guess_extension
 
 PAGE_TEMPLATES_ROOT = settings.BASE_DIR / "sites_conformes/core/page_templates"
 TEMPLATES_DATA_FILE = PAGE_TEMPLATES_ROOT / "pages_data.json"
@@ -111,7 +111,7 @@ class ImportPages:
         self,
         pages_data: dict | None = None,
         parent_page_slug: str | None = None,
-        image_folder: PosixPath | None = IMAGES_FOLDER,
+        image_folder: Path | None = IMAGES_FOLDER,
     ) -> None:
         if pages_data is None:
             with open(TEMPLATES_DATA_FILE, "r") as json_file:
@@ -205,7 +205,7 @@ class ImportExportImages:
     Generic class for import/export of a list of Images from a wagtail instance
     """
 
-    def __init__(self, image_ids, source_site=None, image_folder: PosixPath | None = IMAGES_FOLDER) -> None:
+    def __init__(self, image_ids, source_site=None, image_folder: Path | None = IMAGES_FOLDER) -> None:
         self.user = User.objects.filter(is_superuser=True).first()
 
         self.image_ids = set(image_ids)
@@ -213,7 +213,7 @@ class ImportExportImages:
 
         # Create the folder for the files if it doesn't exist
         self.image_folder = image_folder
-        os.makedirs(image_folder, exist_ok=True)
+        image_folder.mkdir(parents=True, exist_ok=True)
 
         self.image_data_file = self.image_folder / "image_data.json"  # type: ignore
 
@@ -223,7 +223,7 @@ class ImportExportImages:
         self.image_data = self.get_image_data()
 
     def get_image_data(self) -> dict:
-        if os.path.isfile(self.image_data_file):
+        if self.image_data_file.is_file():
             with open(self.image_data_file, "r") as json_file:
                 image_data = json.load(json_file)
         else:
@@ -254,7 +254,7 @@ class ImportExportImages:
             # No need to export the pictograms, as they should already be present
             if "Pictogrammes_DSFR" in image_name:
                 pictogram_title = image_name.replace("__", " — ").replace("_", " ")
-                self.image_data[i]["filename"] = pictogram_title
+                self.image_data[i]["filename"] = f"{pictogram_title}.svg"
                 self.image_data[i]["is_pictogram"] = True
 
             else:
@@ -270,10 +270,9 @@ class ImportExportImages:
         for i in self.image_ids:
             i = str(i)
             image_data = self.image_data[i]
-            filename = image_data["filename"]
 
             if image_data["is_pictogram"]:
-                pictogram = Image.objects.filter(title=filename).first()
+                pictogram = Image.objects.filter(title=image_data["title"]).first()
                 image_data["local_id"] = pictogram.id
             else:
                 image = self.get_or_create_image(image_data)
@@ -281,7 +280,6 @@ class ImportExportImages:
 
     def get_or_create_image(self, image_data) -> Image:
         filename = image_data["filename"]
-        imported_filename = f"template_image_{filename.lower()}"
         title = image_data["title"]
 
         with open(self.image_folder / filename, "rb") as image_file:
@@ -289,8 +287,13 @@ class ImportExportImages:
 
             image = Image.objects.filter(file_hash=file_hash).first()
             if not image:
+                image_file.seek(0)
+                content = image_file.read()
+                stem = Path(filename.lower()).stem
+                ext = guess_extension(filename, content)
+                imported_filename = f"template_image_{stem}{ext}"
                 image = Image(
-                    file=ImageFile(BytesIO(image_file.read()), name=imported_filename),
+                    file=ImageFile(BytesIO(content), name=imported_filename),
                     title=title,
                     uploaded_by_user=self.user,
                     collection=self.collection,

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/card_horizontal.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/card_horizontal.html
@@ -56,7 +56,7 @@
   </div>
   {% if value.image %}
     <div class="fr-card__header">
-      <div class="fr-card__img">{% picture value.image width-1200 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="" preserve-svg %}</div>
+      <div class="fr-card__img">{% picture value.image width-1200 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="" %}</div>
       {% if value.image_badge %}
         <ul class="fr-badges-group">
           {% for badge in value.image_badge %}

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/card_horizontal.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/card_horizontal.html
@@ -56,7 +56,7 @@
   </div>
   {% if value.image %}
     <div class="fr-card__header">
-      <div class="fr-card__img">{% image value.image width-1200 class="fr-responsive-img" %}</div>
+      <div class="fr-card__img">{% picture value.image width-1200 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="" preserve-svg %}</div>
       {% if value.image_badge %}
         <ul class="fr-badges-group">
           {% for badge in value.image_badge %}

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/card_vertical.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/card_vertical.html
@@ -49,7 +49,7 @@
   </div>
   <div class="fr-card__header">
     {% if value.image %}
-      <div class="fr-card__img">{% image value.image width-1200 class=value.image_classes %}</div>
+      <div class="fr-card__img">{% picture value.image width-1200 format-{avif,webp,jpeg} preserve-svg class=value.image_classes alt="" %}</div>
       {% if value.image_badge %}
         <ul class="fr-badges-group">
           {% for badge in value.image_badge %}

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/contact_card_vertical.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/contact_card_vertical.html
@@ -44,12 +44,7 @@
     <div class="fr-card__header">
       <div class="fr-card__img">
         <div class="cmsfr-vertical_contact_card__header fr-py-2w">
-          {% image value.display.image fill-200x200 as contact_image %}
-          <img class="cmsfr-vertical_contact_card-img fr-py-2w"
-               src="{{ contact_image.url }}"
-               width="4.5em"
-               height="4.5em"
-               alt="{{ contact_image.alt }}" />
+          {% picture value.display.image fill-200x200 format-{avif,webp,jpeg} preserve-svg class="cmsfr-vertical_contact_card-img fr-py-2w" alt="" width="4.5em" height="4.5em" %}
         </div>
       </div>
     </div>

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/image.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/image.html
@@ -8,11 +8,11 @@
   <div class="fr-content-media__img">
     {% if value.url %}
       <a href="{{ value.url }}">
-        {% image value.image original class=value.extra_classes %}
+        {% picture value.image original format-{avif,webp,jpeg} preserve-svg class=value.extra_classes alt=value.alt %}
         <span class="fr-sr-only">{% translate "Go to page" %} {{ value.url }}</span>
       </a>
     {% else %}
-      {% image value.image original class=value.extra_classes %}
+      {% picture value.image original format-{avif,webp,jpeg} preserve-svg class=value.extra_classes alt=value.alt %}
     {% endif %}
   </div>
   {% if value.caption %}<figcaption class="fr-content-media__caption">{{ value.caption }}</figcaption>{% endif %}

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/image_svg_or_raster.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/image_svg_or_raster.html
@@ -13,8 +13,8 @@
   </div>
 {% else %}
   {% if alt %}
-    {% image value.image original class=extra_classes alt=alt %}
+    {% picture value.image original format-{avif,webp,jpeg} preserve-svg class=extra_classes alt=alt %}
   {% else %}
-    {% image value.image original class=extra_classes %}
+    {% picture value.image original format-{avif,webp,jpeg} preserve-svg class=extra_classes %}
   {% endif %}
 {% endif %}

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/sections/image_text_cta.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/sections/image_text_cta.html
@@ -13,10 +13,7 @@
 
     </div>
     <div class="fr-col-md-6">
-      {% image value.image fill-600x600 as image %}
-      <img class="fr-responsive-img"
-           src="{{ image.full_url }}"
-           alt="{{ image.alt }}" />
+      {% picture value.image fill-600x600 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="{{ image.alt }}" %}
     </div>
   </div>
 

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/sections/image_text_cta.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/sections/image_text_cta.html
@@ -13,7 +13,7 @@
 
     </div>
     <div class="fr-col-md-6">
-      {% picture value.image fill-600x600 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="{{ image.alt }}" %}
+      {% picture value.image fill-600x600 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="{{ value.image.contextual_alt_text }}" %}
     </div>
   </div>
 

--- a/sites_conformes/core/templates/sites_conformes_core/blocks/tile.html
+++ b/sites_conformes/core/templates/sites_conformes_core/blocks/tile.html
@@ -52,7 +52,7 @@
           </svg>
         </div>
       {% else %}
-        <div class="fr-tile__img">{% image value.image width-80 alt="" %}</div>
+        <div class="fr-tile__img">{% picture value.image width-80 format-{avif,webp,jpeg} preserve-svg alt="" %}</div>
       {% endif %}
     </div>
   {% endif %}

--- a/sites_conformes/core/templates/sites_conformes_core/heros/hero_image_text.html
+++ b/sites_conformes/core/templates/sites_conformes_core/heros/hero_image_text.html
@@ -8,10 +8,7 @@
         {% include "sites_conformes_core/heros/_hero_buttons.html" %}
       </div>
        <div class="fr-col-md-6">
-      {% image value.image fill-600x600 as header_image %}
-      <img class="fr-responsive-img"
-           src="{{ header_image.full_url }}"
-           alt="{{ header_image.alt }}" />
+      {% picture value.image fill-600x600 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="{{ header_image.alt }}" %}
     </div>
     </div>
    

--- a/sites_conformes/core/templates/sites_conformes_core/heros/hero_image_text.html
+++ b/sites_conformes/core/templates/sites_conformes_core/heros/hero_image_text.html
@@ -8,7 +8,7 @@
         {% include "sites_conformes_core/heros/_hero_buttons.html" %}
       </div>
        <div class="fr-col-md-6">
-      {% picture value.image fill-600x600 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="{{ header_image.alt }}" %}
+      {% picture value.image fill-600x600 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="{{ value.image.contextual_alt_text }}" %}
     </div>
     </div>
    

--- a/sites_conformes/core/templates/sites_conformes_core/heros/hero_wide_image_text.html
+++ b/sites_conformes/core/templates/sites_conformes_core/heros/hero_wide_image_text.html
@@ -10,7 +10,7 @@
     </div>
     <div class="fr-grid-row fr-grid-row--gutters">
       <figure class="fr-content-media {{ value.image.image_width }} {% if value.text_content.position == 'bottom' %}cmsfr-without-margin{% endif %}">
-        <div class="fr-content-media__img">{% image value.image.image original class=value.image.extra_classes %}</div>
+        <div class="fr-content-media__img">{% picture value.image.image original format-{avif,webp,jpeg} preserve-svg class=value.image.extra_classes %}</div>
       </figure>
     </div>
   </div>

--- a/sites_conformes/core/templates/sites_conformes_core/widgets/pictogram.html
+++ b/sites_conformes/core/templates/sites_conformes_core/widgets/pictogram.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
 
 <figure>
-  {% image value height-80 loading="lazy" %}
+  {% picture value height-80 format-{avif,webp,jpeg} preserve-svg loading="lazy" %}
 </figure>

--- a/sites_conformes/core/tests/test_services_import_export.py
+++ b/sites_conformes/core/tests/test_services_import_export.py
@@ -1,7 +1,9 @@
 from django.core.management import call_command
+from django.test import SimpleTestCase
 from wagtail.test.utils import WagtailPageTestCase
 
 from sites_conformes.core.models import ContentPage
+from sites_conformes.core.utils import guess_extension
 
 
 class ImportPagesTestCase(WagtailPageTestCase):
@@ -22,3 +24,46 @@ class ImportPagesTestCase(WagtailPageTestCase):
             ContentPage.objects.child_of(self.templates_index).filter(source_url=template.source_url).first()
         )
         self.assertEqual(template.id, find_template.id)
+
+
+class GuessExtensionTestCase(SimpleTestCase):
+    """Unit tests for guess_extension — no DB required."""
+
+    def _call(self, filename, content=b""):
+        return guess_extension(filename, content)
+
+    def test_svg_extension_preserved(self):
+        self.assertEqual(self._call("icon.svg"), ".svg")
+
+    def test_png_extension_preserved(self):
+        self.assertEqual(self._call("photo.PNG"), ".png")
+
+    def test_jpg_extension_preserved(self):
+        self.assertEqual(self._call("photo.jpg"), ".jpg")
+
+    def test_sniff_png(self):
+        self.assertEqual(self._call("image", b"\x89PNG rest of header"), ".png")
+
+    def test_sniff_jpg(self):
+        self.assertEqual(self._call("image", b"\xff\xd8\xff rest"), ".jpg")
+
+    def test_sniff_gif87(self):
+        self.assertEqual(self._call("image", b"GIF87a rest"), ".gif")
+
+    def test_sniff_gif89(self):
+        self.assertEqual(self._call("image", b"GIF89a rest"), ".gif")
+
+    def test_sniff_webp(self):
+        self.assertEqual(self._call("image", b"RIFF\x00\x00\x00\x00WEBP rest"), ".webp")
+
+    def test_sniff_svg(self):
+        svg = b'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'
+        self.assertEqual(self._call("image", svg), ".svg")
+
+    def test_sniff_svg_uppercase_tag(self):
+        # The check lowercases the bytes before searching
+        svg = b"<SVG xmlns='http://www.w3.org/2000/svg'></SVG>"
+        self.assertEqual(self._call("image", svg), ".svg")
+
+    def test_unknown_content_returns_empty(self):
+        self.assertEqual(self._call("image", b"\x00\x01\x02\x03"), "")

--- a/sites_conformes/core/tests/test_services_import_export.py
+++ b/sites_conformes/core/tests/test_services_import_export.py
@@ -56,6 +56,13 @@ class GuessExtensionTestCase(SimpleTestCase):
     def test_sniff_webp(self):
         self.assertEqual(self._call("image", b"RIFF\x00\x00\x00\x00WEBP rest"), ".webp")
 
+    def test_sniff_avif(self):
+        # ISOBMFF: 4-byte box size, "ftyp" box type, then the "avif" brand.
+        self.assertEqual(self._call("image", b"\x00\x00\x00\x20ftypavif rest"), ".avif")
+
+    def test_sniff_avif_sequence_brand(self):
+        self.assertEqual(self._call("image", b"\x00\x00\x00\x20ftypavis rest"), ".avif")
+
     def test_sniff_svg(self):
         svg = b'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'
         self.assertEqual(self._call("image", svg), ".svg")

--- a/sites_conformes/core/tests/test_utils.py
+++ b/sites_conformes/core/tests/test_utils.py
@@ -13,3 +13,4 @@ class UtilsTestCase(WagtailPageTestCase):
 
         assert isinstance(image, Image)
         assert image.title == "Sample image"
+        assert image.file.name.endswith(".svg")

--- a/sites_conformes/core/utils.py
+++ b/sites_conformes/core/utils.py
@@ -26,8 +26,7 @@ def _build_image_name(full_file_path: str, content: bytes) -> str:
     ext = guess_extension(full_file_path, content)
     if not ext:
         logger.warning(
-            "Could not determine an extension for image %r; storing it without "
-            "one may break rendition generation.",
+            "Could not determine an extension for image %r; storing it without " "one may break rendition generation.",
             full_file_path,
         )
     return f"{path.stem}{ext}"

--- a/sites_conformes/core/utils.py
+++ b/sites_conformes/core/utils.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from html import unescape
 from io import BytesIO
@@ -8,7 +9,28 @@ from django.core.files.images import ImageFile
 from wagtail.images import get_image_model
 from wagtail.models import Site
 
+logger = logging.getLogger(__name__)
+
 Image = get_image_model()
+
+
+def _build_image_name(full_file_path: str, content: bytes) -> str:
+    """
+    Build the stored filename for an imported image, ensuring it keeps a usable
+    extension. Wagtail's rendition generation (and the ``{% picture %}`` tag)
+    chokes on files stored without an extension, so we sniff one when missing
+    and log loudly when detection fails rather than silently creating a broken,
+    extension-less image.
+    """
+    path = Path(full_file_path)
+    ext = guess_extension(full_file_path, content)
+    if not ext:
+        logger.warning(
+            "Could not determine an extension for image %r; storing it without "
+            "one may break rendition generation.",
+            full_file_path,
+        )
+    return f"{path.stem}{ext}"
 
 
 def guess_extension(filename: str, file_content: bytes) -> str:
@@ -29,20 +51,22 @@ def guess_extension(filename: str, file_content: bytes) -> str:
         return ".gif"
     if file_content[:4] == b"RIFF" and file_content[8:12] == b"WEBP":
         return ".webp"
+    # AVIF / HEIF share the ISOBMFF "ftyp" box; the brand at bytes 8-12
+    # distinguishes AVIF. WAGTAILIMAGES_EXTENSIONS now allows avif uploads.
+    if file_content[4:8] == b"ftyp" and file_content[8:12] in (b"avif", b"avis"):
+        return ".avif"
     if b"<svg" in file_content[:512].lower():
         return ".svg"
 
     return ""
 
 
-def import_image(full_file_path: str, title: str):
+def import_image(full_file_path: str, title: str) -> Image:
     """
     Import an image to the Wagtail medias based on its full path and return it.
     """
-    path = Path(full_file_path)
-    content = path.read_bytes()
-    ext = guess_extension(full_file_path, content)
-    name = f"{path.stem}{ext}"
+    content = Path(full_file_path).read_bytes()
+    name = _build_image_name(full_file_path, content)
     image = Image(
         file=ImageFile(BytesIO(content), name=name),
         title=title,
@@ -51,15 +75,13 @@ def import_image(full_file_path: str, title: str):
     return image
 
 
-def overwrite_image(image, full_file_path: str, title: str):
+def overwrite_image(image, full_file_path: str, title: str) -> Image:
     """
     Overwrites the file for a Wagtail image instance,
     keeping the same database record and ID.
     """
-    path = Path(full_file_path)
-    content = path.read_bytes()
-    ext = guess_extension(full_file_path, content)
-    name = f"{path.stem}{ext}"
+    content = Path(full_file_path).read_bytes()
+    name = _build_image_name(full_file_path, content)
     image.file = ImageFile(BytesIO(content), name=name)
     image.save()
     return image

--- a/sites_conformes/events/templates/sites_conformes_events/event_entry_page.html
+++ b/sites_conformes/events/templates/sites_conformes_events/event_entry_page.html
@@ -138,8 +138,7 @@
       <div class="fr-card__header">
         <div class="fr-card__img">
           {% if page.cover %}
-            {% image page.cover width-450 as header_image %}
-            <img class="fr-responsive-img" src="{{ header_image.url}}" alt="" />
+            {% picture page.cover width-450 format-{avif,webp,jpeg} preserve-svg class="fr-responsive-img" alt="" %}
           {% else %}
             <img class="fr-responsive-img"
                  src="{% static 'dsfr/dist/artwork/pictograms/digital/calendar.svg' %}"


### PR DESCRIPTION
## 🎯 Objectif

Utilisation du tag picture de wagtail

## TODO
- [x] Ajouter script de migration pour sites existant, migrer `Pictogramme XY` -> `Pictogramme XY.svg`
- [ ] ajout e2e

## 🔍 Implémentation

Cf https://docs.wagtail.org/en/stable/advanced_topics/images/image_file_formats.html#using-the-picture-element  
- Remplacement de `{% image %}` par `{% picture %}`


## ⚠️ Informations supplémentaires

Comment tester : 
- en local, générer des données de démo 
- `docker compose exec -ti web uv run python manage.py create_demo_pages` 
- puis corriger les images existantes qui n'ont pas la bonne extensions
- `docker compose exec -ti web uv run python manage.py fix_svg_images_extensions` (possible de lancer avec --dry-run si jamais on veut controler avant) 

Sinon : 
- inspecter une image (svg, ou bitmap)
- vérifier qu'elle a bien un tag `<picture><img></picture>`
- vérifier qu'elle s'affiche bien dans le browser
- si c'est un bitmap, véifier qu'elle a bien les 3 versions: webp, jpg, avif

## 🏕 Amélioration continue

- J'ai eu des soucis avec le script de génération d'images / pictos qui générait des fichiers sans extension (`.svg`), ce qui fausse une méthode de wagtail qui permet de gérer les rendus d'image (https://github.com/wagtail/wagtail/blob/3f261d831003017d26dece999433d32749290656/wagtail/images/models.py#L900). 
- J'ai donc corrigé le script + revu la manière de gérer les path en utilisant `pathlib` plutôt que `os` qui est plus récent et plus dev-friendly
