### PR TITLE
Correction des classes de formulaires manquantes

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -343,7 +343,7 @@ if FORCE_SCRIPT_NAME and not STATIC_URL.startswith(FORCE_SCRIPT_NAME):
 
 
 # Allow Django to serve statics even in production if needed
-SF_PROD_SERVE_STATIC = True if os.getenv("SF_PROD_SERVE_STATIC", False) in ["1", "True"] else False
+SF_PROD_SERVE_STATIC = getenv_bool("SF_PROD_SERVE_STATIC", False)
 if SF_PROD_SERVE_STATIC:
     import mimetypes
 
@@ -449,7 +449,7 @@ WAGTAILDOCS_MAX_UPLOAD_SIZE = int(os.getenv("WAGTAILDOCS_MAX_UPLOAD_SIZE", 10 * 
 
 WAGTAILIMAGES_EXTENSIONS = ["gif", "jpg", "jpeg", "png", "webp", "svg"]
 WAGTAILDOCS_EXTENSIONS = ["pdf", "docx", "odt", "xlsx", "ods", "pptx", "odp", "csv", "txt"]
-SF_SCHEME_DEPENDENT_SVGS = True if os.getenv("SF_SCHEME_DEPENDENT_SVGS", False) in ["1", "True"] else False
+SF_SCHEME_DEPENDENT_SVGS = getenv_bool("SF_SCHEME_DEPENDENT_SVGS", False)
 
 # Allows for complex Streamfields without completely removing checks
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
@@ -471,11 +471,14 @@ if DEFAULT_FROM_EMAIL:
     EMAIL_SSL_KEYFILE = os.getenv("EMAIL_SSL_KEYFILE", None)
     EMAIL_SSL_CERTFILE = os.getenv("EMAIL_SSL_CERTFILE", None)
 
-WAGTAIL_PASSWORD_RESET_ENABLED = os.getenv("WAGTAIL_PASSWORD_RESET_ENABLED", False)
+# Forms
+WAGTAIL_PASSWORD_RESET_ENABLED = getenv_bool("WAGTAIL_PASSWORD_RESET_ENABLED", False)
+WAGTAILADMIN_USER_PASSWORD_RESET_FORM = "sites_conformes.dashboard.forms.DsfrPasswordResetForm"
+DSFR_MARK_OPTIONAL_FIELDS = getenv_bool("DSFR_MARK_OPTIONAL_FIELDS", True)
 
 # (Optional) ProConnect settings
-PROCONNECT_ACTIVATED = True if os.getenv("PROCONNECT_ACTIVATED", False) in ["1", "True"] else False
-OIDC_CREATE_USER = True if os.getenv("PROCONNECT_CREATE_USER", "True") in ["1", "True"] else False
+PROCONNECT_ACTIVATED = getenv_bool("PROCONNECT_ACTIVATED", False)
+OIDC_CREATE_USER = getenv_bool("PROCONNECT_CREATE_USER", True)
 OIDC_RP_CLIENT_ID = os.getenv("PROCONNECT_CLIENT_ID", "")
 OIDC_RP_CLIENT_SECRET = os.getenv("PROCONNECT_CLIENT_SECRET", "")
 OIDC_RP_SCOPES = os.getenv("PROCONNECT_SCOPES", "openid given_name usual_name email siret uid")
@@ -493,7 +496,7 @@ OIDC_AUTH_REQUEST_EXTRA_PARAMS = {"acr_values": "eidas1"}
 OIDC_REDIRECT_ALLOWED_HOSTS = ALLOWED_HOSTS
 PROCONNECT_USER_CREATION_FILTER = os.getenv("PROCONNECT_USER_CREATION_FILTER", None)
 LASUITE_DOMAINE_API_KEY = os.getenv("LASUITE_DOMAINE_API_KEY", None)
-SF_DISABLE_LOCAL_LOGIN = True if os.getenv("SF_DISABLE_LOCAL_LOGIN") in ["1", "True"] else False
+SF_DISABLE_LOCAL_LOGIN = getenv_bool("SF_DISABLE_LOCAL_LOGIN", False)
 
 LOGIN_REDIRECT_URL = f"{FORCE_SCRIPT_NAME}/"
 LOGOUT_REDIRECT_URL = f"{FORCE_SCRIPT_NAME}/"
@@ -528,9 +531,9 @@ if len(trusted_origins):
 
 # Disable the integrity checksums by default.
 # They can clash with Whitenoise and are normally not useful as we serve the statics from a trusted source
-DSFR_USE_INTEGRITY_CHECKSUMS = True if os.getenv("DSFR_USE_INTEGRITY_CHECKSUMS") in ["1", "True"] else False
+DSFR_USE_INTEGRITY_CHECKSUMS = getenv_bool("DSFR_USE_INTEGRITY_CHECKSUMS", False)
 
-SF_DISABLE_TUTORIALS = True if os.getenv("SF_DISABLE_TUTORIALS") in ["1", "True"] else False
+SF_DISABLE_TUTORIALS = getenv_bool("SF_DISABLE_TUTORIALS", False)
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 # Legacy clickjacking fallback for browsers without CSP frame-ancestors

--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,7 @@ from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
 
 from config.api import api_router
+from sites_conformes.dashboard.views import PasswordResetConfirmView
 from sites_conformes.proconnect import urls as oidc_urls
 
 TEMPLATE_404 = "sites_conformes_core/404.html"
@@ -19,6 +20,11 @@ TEMPLATE_500 = "sites_conformes_core/500.html"
 
 urlpatterns = [
     path("sitemap.xml", sitemap, name="xml_sitemap"),
+    path(
+        f"{settings.WAGTAILADMIN_PATH}password_reset/confirm/<uidb64>/<token>/",
+        PasswordResetConfirmView.as_view(),
+        name="wagtailadmin_password_reset_confirm",
+    ),
     path(settings.WAGTAILADMIN_PATH, include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("api/v2/", api_router.urls),

--- a/sites_conformes/dashboard/forms.py
+++ b/sites_conformes/dashboard/forms.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.forms import SetPasswordForm
+from wagtail.admin.forms.auth import PasswordResetForm as WagtailPasswordResetForm
+
+from sites_conformes.forms.baseform import SitesFacilesBaseForm
+
+
+class DsfrPasswordResetForm(SitesFacilesBaseForm, WagtailPasswordResetForm):
+    pass
+
+
+class DsfrSetPasswordForm(SitesFacilesBaseForm, SetPasswordForm):
+    pass

--- a/sites_conformes/dashboard/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/sites_conformes/dashboard/templates/wagtailadmin/account/password_reset/confirm.html
@@ -1,5 +1,5 @@
 {% extends "sites_conformes_core/base.html" %}
-{% load widget_tweaks wagtailadmin_tags i18n static dsfr_tags %}
+{% load widget_tweaks wagtailadmin_tags i18n static %}
 {% block content %}
   <div class="fr-container fr-container--fluid fr-my-md-14v">
     {% if validlink %}
@@ -21,8 +21,8 @@
                 <form method="post" novalidate>
                   {% csrf_token %}
 
-                  {% dsfr_form_field form.new_password1 %}
-                  {% dsfr_form_field form.new_password2 %}
+                  {{ form.new_password1.as_field_group }}
+                  {{ form.new_password2.as_field_group }}
 
                   <button type="submit" class="fr-btn">{% translate "Reset password" %}</button>
                 </form>

--- a/sites_conformes/dashboard/templates/wagtailadmin/account/password_reset/form.html
+++ b/sites_conformes/dashboard/templates/wagtailadmin/account/password_reset/form.html
@@ -1,5 +1,5 @@
 {% extends "sites_conformes_core/base.html" %}
-{% load widget_tweaks wagtailadmin_tags i18n static dsfr_tags %}
+{% load widget_tweaks wagtailadmin_tags i18n static %}
 {% block content %}
   <div class="fr-container fr-container--fluid fr-my-md-14v">
     <div class="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
@@ -13,8 +13,8 @@
               <form method="post" novalidate>
                 {% csrf_token %}
 
-                {% dsfr_form_field form.email %}
-
+                {{ form.email.as_field_group }}
+                
                 <button type="submit" class="fr-btn">{% translate "Reset password" %}</button>
               </form>
             </div>

--- a/sites_conformes/dashboard/tests/test_password_reset_forms.py
+++ b/sites_conformes/dashboard/tests/test_password_reset_forms.py
@@ -1,0 +1,87 @@
+"""
+Regression tests for the DSFR styling of the Wagtail admin password reset forms.
+
+django-dsfr 3.5.x changed `{% dsfr_form_field %}` / `{{ field.as_field_group }}` to only
+produce DSFR markup for forms whose bound_field_class is dsfr.forms.DsfrBoundField (i.e.
+forms subclassing dsfr.forms.DsfrBaseForm). Wagtail's built-in password reset forms don't,
+so they silently lost their styling. sites_conformes.dashboard.forms.DsfrPasswordResetForm
+and DsfrSetPasswordForm fix this; config.settings.WAGTAILADMIN_USER_PASSWORD_RESET_FORM and
+the wagtailadmin_password_reset_confirm URL override in config.urls wire them into the
+actual views.
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.test import TestCase, override_settings
+from django.urls import resolve, reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from dsfr.forms import DsfrBoundField
+
+from sites_conformes.dashboard.forms import DsfrPasswordResetForm, DsfrSetPasswordForm
+
+User = get_user_model()
+
+
+class PasswordResetFormsDsfrRenderingTestCase(TestCase):
+    """Form-level checks: DSFR markup doesn't depend on going through a view."""
+
+    def test_password_reset_form_email_field_is_dsfr_styled(self):
+        form = DsfrPasswordResetForm()
+
+        bound_field = form["email"]
+        self.assertIsInstance(bound_field, DsfrBoundField)
+
+        html = str(bound_field.as_field_group())
+        self.assertIn("fr-input-group", html)
+        self.assertIn('class="fr-input"', html)
+
+    def test_set_password_form_fields_are_dsfr_styled(self):
+        user = User(username="jane", email="jane@example.com")
+        form = DsfrSetPasswordForm(user=user)
+
+        for field_name in ["new_password1", "new_password2"]:
+            bound_field = form[field_name]
+            self.assertIsInstance(bound_field, DsfrBoundField)
+
+            html = str(bound_field.as_field_group())
+            self.assertIn("fr-input-group", html)
+            self.assertIn('class="fr-input"', html)
+
+
+@override_settings(WAGTAIL_PASSWORD_RESET_ENABLED=True)
+class PasswordResetViewsDsfrRenderingTestCase(TestCase):
+    """End-to-end checks that the actual admin views render the DSFR-styled forms."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="jane", email="jane@example.com", password="a-strong-password-123"
+        )
+
+    def test_password_reset_view_renders_dsfr_markup(self):
+        response = self.client.get(reverse("wagtailadmin_password_reset"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "fr-input-group")
+        self.assertContains(response, 'class="fr-input"')
+
+    def test_password_reset_confirm_url_is_overridden_with_dsfr_view(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = default_token_generator.make_token(self.user)
+        url = reverse("wagtailadmin_password_reset_confirm", kwargs={"uidb64": uid, "token": token})
+
+        match = resolve(url)
+        self.assertIs(match.func.view_class.form_class, DsfrSetPasswordForm)
+
+    def test_password_reset_confirm_view_renders_dsfr_markup(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = default_token_generator.make_token(self.user)
+        url = reverse("wagtailadmin_password_reset_confirm", kwargs={"uidb64": uid, "token": token})
+
+        # Django's PasswordResetConfirmView redirects the token out of the URL and into the
+        # session on first GET, so the actual form is only served on the followed response.
+        response = self.client.get(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "fr-input-group")
+        self.assertContains(response, 'class="fr-input"')

--- a/sites_conformes/dashboard/views.py
+++ b/sites_conformes/dashboard/views.py
@@ -6,8 +6,10 @@ from django.core.cache import cache
 from django.urls import reverse
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.ui.components import Component
+from wagtail.admin.views.account import PasswordResetConfirmView as WagtailPasswordResetConfirmView
 from wagtail.models import Site
 
+from sites_conformes.dashboard.forms import DsfrSetPasswordForm
 from sites_conformes.dashboard.notifications import get_all_notifications
 
 finder = AdminURLFinder()
@@ -103,3 +105,10 @@ class NotificationPanel(Component):
                     pass
             notifications.append(item)
         return {"notifications": notifications}
+
+
+class PasswordResetConfirmView(WagtailPasswordResetConfirmView):
+    # Wagtail hard-codes django.contrib.auth.forms.SetPasswordForm, which isn't DSFR-styled.
+    # There's no settings hook for it (unlike WAGTAILADMIN_USER_PASSWORD_RESET_FORM), so the
+    # URL below overrides the one from wagtailadmin_urls (matched first by Django).
+    form_class = DsfrSetPasswordForm

--- a/sites_conformes/forms/models.py
+++ b/sites_conformes/forms/models.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from dsfr.forms import DsfrDjangoTemplates
+from dsfr.forms import DsfrBoundField, DsfrDjangoTemplates
 from dsfr.utils import dsfr_input_class_attr
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel
@@ -62,6 +62,7 @@ class SitesFacilesCustomForm(BaseForm):
     """
 
     template_name = "dsfr/form_snippet.html"  # type: ignore
+    bound_field_class = DsfrBoundField
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/sites_conformes/forms/templates/sites_conformes_forms/form_page.html
+++ b/sites_conformes/forms/templates/sites_conformes_forms/form_page.html
@@ -1,5 +1,5 @@
 {% extends "sites_conformes_core/base.html" %}
-{% load wagtailcore_tags dsfr_tags i18n honeypot_tags static %}
+{% load wagtailcore_tags wagtail_dsfr_tags i18n honeypot_tags static %}
 
 {% block extra_css %}
   <link rel="stylesheet" href="{% static 'css/honeypot.css' %}">
@@ -22,13 +22,16 @@
     {{ page.intro|richtext }}
 
     <form action="{% pageurl page %}" method="post" autocomplete="on">
-      <div class="fr-fieldset__element">
-        {% if page.all_fields_required %}
-          <p class="fr-text--sm">{% translate "All fields are mandatory." %}</p>
-        {% else %}
-          <p class="fr-text--sm">{% translate "Fields marked with an asterisk (*) are mandatory." %}</p>
-        {% endif %}
-      </div>
+      {% settings_value "DSFR_MARK_OPTIONAL_FIELDS" as dsfr_mark_optional_fields %}
+      {% if not dsfr_mark_optional_fields %}
+        <div class="fr-fieldset__element">
+          {% if page.all_fields_required %}
+            <p class="fr-text--sm">{% translate "All fields are mandatory." %}</p>
+          {% else %}
+            <p class="fr-text--sm">{% translate "Fields marked with an asterisk (*) are mandatory." %}</p>
+          {% endif %}
+        </div>
+      {% endif %}
 
       {% csrf_token %}
       {% if form.non_field_errors %}
@@ -40,7 +43,7 @@
       {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
 
       {% for field in form.visible_fields %}
-        <div class="fr-fieldset__element">{% dsfr_form_field field %}</div>
+        <div class="fr-fieldset__element">{{ field.as_field_group }}</div>
       {% endfor %}
 
       {% honeypot_fields page.honeypot %}

--- a/sites_conformes/forms/tests/test_forms.py
+++ b/sites_conformes/forms/tests/test_forms.py
@@ -1,9 +1,11 @@
 from django.core.management import call_command
+from django.test import SimpleTestCase
 from django.urls import reverse
+from dsfr.forms import DsfrBoundField
 from wagtail.test.utils import WagtailPageTestCase
 from wagtail_localize.models import TranslationSource
 
-from sites_conformes.forms.models import FormField, FormPage
+from sites_conformes.forms.models import FormField, FormPage, SitesFacilesFormBuilder
 
 
 class FormsTestCase(WagtailPageTestCase):
@@ -124,3 +126,38 @@ class FormsTestCase(WagtailPageTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertInHTML("""<a href="/contact/">Contact</a>""", response.content.decode())
         self.assertInHTML("""<h1>1 résultat pour la recherche «\xa0contact\xa0»</h1>""", response.content.decode())
+
+
+class SitesFacilesCustomFormDsfrRenderingTestCase(SimpleTestCase):
+    """
+    Regression test: SitesFacilesCustomForm (used by SitesFacilesFormBuilder for every public
+    FormPage) must keep dispatching to DSFR's per-widget snippet templates. It only sets the
+    "fr-input"/"fr-select" classes itself (via dsfr_input_class_attr); checkboxes and radio
+    buttons get no styling at all unless bound_field_class is DsfrBoundField, since their
+    markup (fr-checkbox-group, fr-fieldset/legend, etc.) comes entirely from those snippets.
+    """
+
+    def build_form(self, **fields):
+        builder = SitesFacilesFormBuilder(list(fields.values()))
+        return builder.get_form_class()()
+
+    def test_checkbox_field_has_dsfr_markup(self):
+        checkbox = FormField(field_type="checkbox", label="Accepte les conditions", required=True)
+        form = self.build_form(checkbox=checkbox)
+
+        bound_field = form["accepte_les_conditions"]
+        self.assertIsInstance(bound_field, DsfrBoundField)
+
+        html = str(bound_field.as_field_group())
+        self.assertIn("fr-checkbox-group", html)
+
+    def test_radio_field_has_dsfr_markup(self):
+        radio = FormField(field_type="radio", label="Choix", required=True, choices="A, B")
+        form = self.build_form(radio=radio)
+
+        bound_field = form["choix"]
+        self.assertIsInstance(bound_field, DsfrBoundField)
+
+        html = str(bound_field.as_field_group())
+        self.assertIn("fr-fieldset", html)
+        self.assertIn("fr-radio-group", html)


### PR DESCRIPTION
## 🎯 Objectif
Une mise à jour de Django-DSFR (https://github.com/numerique-gouv/django-dsfr/pull/254 ) a fait que les formulaires doivent maintenant explicitement utiliser les classes du DSFR. Cette PR introduit les changements nécessaires.

## 🔍 Implémentation
- [x] Correction des formulaires de renouvellement de mot de passe (formulaire de demande d'email et formulaire d'entrée du nouveau mot de passe)
- [x] Correction de l'affichage des checkboxes et boutons radios sur les formulaires personnalisés
- [x] Prise en compte de `DSFR_MARK_OPTIONAL_FIELDS` (qui faisait partie des corrections d'accessibilité demandées)

## ⚠️ Informations supplémentaires


## 🏕 Amélioration continue
- [x] Usage de `getenv_bool` sur tous les booléens configurables de `config/settings.py`.

## 🖼️ Images
<img width="2133" height="2146" alt="sites-faciles localhost_8008-Formulaire-avec-tous" src="https://github.com/user-attachments/assets/1bc13a46-9796-4b88-a417-060feeca2164" />
<img width="1784" height="661" alt="Capture d’écran du 2026-08-04 17-16-14" src="https://github.com/user-attachments/assets/d2f7ec32-58a8-458b-b4f7-852e562c55ab" />
<img width="1836" height="1225" alt="Capture d’écran du 2026-08-04 17-16-00" src="https://github.com/user-attachments/assets/75743a13-a1d4-4b5e-8ade-697d00c3253c" />
