### PR TITLE
[Outillage] Activation de uv malware-check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,7 @@ ignore = ["E203", "E266"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+
+# Blocks installation of known malware (typosquatting, deliberately malicious packages)
+[tool.uv.audit]
+malware-check = true


### PR DESCRIPTION
## 🎯 Objectif

Add option so that uv add checks for voluntarily malicious packages (typosquatting etc) and blocks install.
This does not check for know CVEs (use uv audit after install for that).