### PR TITLE
[Bugfix] Correction du comportement des pages d'index de catalogue quand on désélectionne un filtre

### DIFF
--- a/sites_conformes/core/models.py
+++ b/sites_conformes/core/models.py
@@ -135,89 +135,93 @@ class CatalogIndexPage(RoutablePageMixin, SitesFacilesBasePage):
 
         return context
 
+    def _default_filter_context(self, entries: models.QuerySet, selected_tag_slugs: list | None = None) -> dict:
+        """
+        Baseline context for the filter system (no filter applied),
+        overridden by the other _handle_* / _get_filtered_* methods.
+        """
+        return {
+            "entries": entries,
+            "extra_breadcrumbs": None,
+            "extra_title": "",
+            "current_tags": [],
+            "current_tag": None,
+            "selected_tag_slugs": selected_tag_slugs or [],
+        }
+
     def _get_filtered_entries_and_context(self, request: HttpRequest, entries: models.QuerySet) -> dict:
+        """
+        Reads the "tag" GET params and dispatches to the filter mode configured on the page.
+        """
         selected_tag_slugs = request.GET.getlist("tag")
         if not selected_tag_slugs:
-            return {
-                "entries": entries,
-                "extra_breadcrumbs": None,
-                "extra_title": "",
-                "current_tags": [],
-                "selected_tag_slugs": [],
-            }
+            return self._default_filter_context(entries)
 
         if self.filter_selection == self.SINGLE_FILTER:
             return self._handle_single_filter(selected_tag_slugs, entries)
         if self.filter_selection == self.MULTIPLE_FILTERS:
             return self._handle_multiple_filters(selected_tag_slugs, entries)
 
-        return {
-            "entries": entries,
-            "extra_breadcrumbs": None,
-            "extra_title": "",
-            "current_tags": [],
-            "selected_tag_slugs": selected_tag_slugs,
-        }
+        return self._default_filter_context(entries, selected_tag_slugs)
 
     def _handle_single_filter(self, selected_tag_slugs: list, entries: models.QuerySet) -> dict:
+        """
+        Filters entries by exactly one tag (SINGLE_FILTER mode)
+        """
+
         if len(selected_tag_slugs) != 1:
-            return {
-                "entries": entries,
-                "extra_breadcrumbs": None,
-                "extra_title": "",
-                "current_tags": [],
-                "selected_tag_slugs": selected_tag_slugs,
-            }
+            return self._default_filter_context(entries, selected_tag_slugs)
 
         tag_slug = selected_tag_slugs[0]
         tag = get_object_or_404(Tag, slug=tag_slug)
         filtered_entries = entries.filter(tags=tag)
-        current_tags = [tag]
-        extra_breadcrumbs = self._build_breadcrumbs(tag)
-        extra_title = _("Pages tagged with %(tag)s") % {"tag": tag}
 
         return {
-            "entries": filtered_entries,
-            "extra_breadcrumbs": extra_breadcrumbs,
-            "extra_title": extra_title,
-            "current_tags": current_tags,
-            "selected_tag_slugs": selected_tag_slugs,
+            **self._default_filter_context(filtered_entries, selected_tag_slugs),
+            "extra_breadcrumbs": self._build_breadcrumbs(tag),
+            "extra_title": _("Pages tagged with %(tag)s") % {"tag": tag},
+            "current_tags": [tag],
+            "current_tag": tag,
         }
 
     def _handle_multiple_filters(self, selected_tag_slugs: list, entries: models.QuerySet) -> dict:
+        """
+        Filters entries by one or more tags, combined with AND/OR (MULTIPLE_FILTERS mode)
+        """
+
         current_tags = list(Tag.objects.filter(slug__in=selected_tag_slugs))
 
         if not current_tags:
-            return {
-                "entries": entries,
-                "extra_breadcrumbs": None,
-                "extra_title": "",
-                "current_tags": [],
-                "selected_tag_slugs": selected_tag_slugs,
-            }
+            return self._default_filter_context(entries, selected_tag_slugs)
 
         if self.multiple_filter_operator == self.AND_OPERATOR:
             filtered_entries, extra_title = self._apply_and_operator(current_tags, entries)
         else:
             filtered_entries, extra_title = self._apply_or_operator(current_tags, entries)
 
-        extra_breadcrumbs = self._build_breadcrumbs()
-
         return {
-            "entries": filtered_entries,
-            "extra_breadcrumbs": extra_breadcrumbs,
+            **self._default_filter_context(filtered_entries, selected_tag_slugs),
+            "extra_breadcrumbs": self._build_breadcrumbs(),
             "extra_title": extra_title,
             "current_tags": current_tags,
-            "selected_tag_slugs": selected_tag_slugs,
+            "current_tag": current_tags[0] if len(current_tags) == 1 else None,
         }
 
     def _apply_and_operator(self, current_tags: list, entries: models.QuerySet) -> tuple:
+        """
+        Keeps only entries that have all of the given tags.
+        """
+
         for tag in current_tags:
             entries = entries.filter(tags=tag)
         extra_title = _("Pages tagged with all of: %(tags)s") % {"tags": ", ".join([str(t) for t in current_tags])}
         return entries, extra_title
 
     def _apply_or_operator(self, current_tags: list, entries: models.QuerySet) -> tuple:
+        """
+        Keeps entries that have at least one of the given tags.
+        """
+
         q_objects = Q()
         for tag in current_tags:
             q_objects |= Q(tags=tag)
@@ -226,6 +230,10 @@ class CatalogIndexPage(RoutablePageMixin, SitesFacilesBasePage):
         return entries, extra_title
 
     def _build_breadcrumbs(self, tag: Union["Tag", None] = None) -> dict:
+        """
+        Build the breadcrumbs dictionary.
+        """
+
         breadcrumbs = {
             "links": [
                 {"url": self.get_url(), "title": self.title},

--- a/sites_conformes/core/tests/test_views.py
+++ b/sites_conformes/core/tests/test_views.py
@@ -384,6 +384,20 @@ class CatalogIndexPageTestCase(WagtailPageTestCase):
         self.assertContains(response, "Entrée 3")
         self.assertNotContains(response, "Entrée 4")
 
+    def test_single_filter_can_be_unselected(self):
+        self.catalog_index_page.filter_selection = CatalogIndexPage.SINGLE_FILTER
+        self.catalog_index_page.save()
+
+        url = self.catalog_index_page.url + "?tag=tag-1"
+        response = self.client.get(url)
+
+        self.assertEqual(response.context["current_tag"], self.tag1)
+
+        # Clicking the already-selected tag again must remove it from the URL
+        # (toggle_url_filter relies on "current_tag" to detect this), instead
+        # of re-adding it and leaving the filter/results unchanged.
+        self.assertNotContains(response, 'href="?tag=tag-1#posts-list"')
+
     def test_multiple_filter_and(self):
         self.catalog_index_page.filter_selection = CatalogIndexPage.MULTIPLE_FILTERS
         self.catalog_index_page.multiple_filter_operator = CatalogIndexPage.AND_OPERATOR


### PR DESCRIPTION
## 🎯 Objectif
[Bug rapporté](https://projets.numerique.gouv.fr/cards/1732634620014364210) : 

> Lorsqu'on décoche un filtre sur les index de catalogue, la recherche ne se met pas à jour.

## 🔍 Implémentation
- [x] Ajout de la clé `current_tag` manquante dans le dictionnaire de contexte des filtres (quand on est en mode filtre unique)
- [x] Ajout d'une méthode supplémentaire `_default_filter_context()` pour instancier le contexte à l'identique pour tous les filtres, qui est ensuite surchargée par ceux-ci.

## 🏕 Amélioration continue
- [x] Ajout d'un test de non-régression

