### PR TITLE
Correction : le test de recherche ignore la recherche personnalisée

### DIFF
--- a/sites_conformes/forms/tests/test_forms.py
+++ b/sites_conformes/forms/tests/test_forms.py
@@ -1,10 +1,11 @@
+from django.contrib.auth.models import AnonymousUser
 from django.core.management import call_command
-from django.test import SimpleTestCase
-from django.urls import reverse
+from django.test import RequestFactory, SimpleTestCase
 from dsfr.forms import DsfrBoundField
 from wagtail.test.utils import WagtailPageTestCase
 from wagtail_localize.models import TranslationSource
 
+from sites_conformes.core.views import SearchResultsView
 from sites_conformes.forms.models import FormField, FormPage, SitesFacilesFormBuilder
 
 
@@ -120,8 +121,14 @@ class FormsTestCase(WagtailPageTestCase):
     def test_form_page_is_found_in_search_results(self):
         call_command("update_index")
 
-        search_url = reverse("cms_search")
-        response = self.client.get(f"{search_url}?q=contact")
+        # Call the default search view by hand instead of using client.get(reverse("cms_search")).
+        # This is because a custom search view could be registered, and it would change the content
+        # of the search results and their page template.
+        factory = RequestFactory()
+        request = factory.get("/search/", {"q": "contact"})
+        request.user = AnonymousUser()
+        response = SearchResultsView.as_view()(request)
+        response.render()
 
         self.assertEqual(response.status_code, 200)
         self.assertInHTML("""<a href="/contact/">Contact</a>""", response.content.decode())


### PR DESCRIPTION
## 🎯 Objectif

Un des tests du search "normal" de SC peut appeler le custom search par accident, s'il y en a un configuré.
Ce fix appelle la vue "normale" explicitement, pour être sur qu'on teste la bonne. 
C'est un no-op pour sites conformes, mais utile pour les forks.

