### PR TITLE
Job de CI qui vérifie la présence de CVEs quand on modifie les dépendances

### DIFF
--- a/.github/workflows/ci-check-deps-audit.yml
+++ b/.github/workflows/ci-check-deps-audit.yml
@@ -1,0 +1,34 @@
+name: 🔒 CI - Dependency CVE audit
+
+on:
+  pull_request:
+    paths:
+      - "uv.lock"
+      - "pyproject.toml"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/ci-check-deps-audit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Dependency CVE audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Audit Python dependencies (uv.lock)
+        run: uv audit --frozen --preview-features audit-command
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Audit npm dependencies (package-lock.json)
+        run: npm audit --package-lock-only --audit-level=moderate


### PR DESCRIPTION
## 🎯 Objectif

J'ai du mal à suivre quand les bots de github tournent ou pas pour vérifier les dépendences, donc j'ai fait un job pour le faire à chaque fois qu'on change les lockfiles ou le pyproject/project.json. Il run npm audit et uv audit, pour trouver des CVEs.

A vous de voir si c'est redite par rapport à ce que vous avez, et si vous voulez le rendre bloquant ou juste informatif.

Note que j'ai pas testé si il marche parce que je voulais pas introduire de CVE :) mais peut-être que ya plus malin pour tester...