### PR TITLE
Ajouter la date de BlogEntryPage comme champ FilterField pour le search

### DIFF
--- a/sites_conformes/blog/models.py
+++ b/sites_conformes/blog/models.py
@@ -518,6 +518,10 @@ class BlogEntryPage(SitesFacilesBasePage):
         "sites_conformes_blog.Person", blank=True, help_text=_("Author entries can be created in Snippets > Persons")
     )
 
+    search_fields = SitesFacilesBasePage.search_fields + [
+        index.FilterField("date"),
+    ]
+
     parent_page_types = ["sites_conformes_blog.BlogIndexPage"]
     subpage_types = []
 


### PR DESCRIPTION
## 🎯 Objectif

Dans le model de BlogEntryPage, ajouter le champ `date` comme `FilterField`. 
Ca permet de faire du filtrage par date pour le search (voir doc : https://docs.wagtail.org/en/7.0/topics/search/indexing.html#index-filterfield)
C'est pas utilisé dans SC actuellement, mais dans Agreste on l'utilise, et ca semble une utilisation courante qui pourrait servir à d'autres, donc je le propose pour tout le monde.