### PR TITLE
Indexer l'en-tête (hero) for search

### DIFF
--- a/sites_conformes/core/abstract.py
+++ b/sites_conformes/core/abstract.py
@@ -126,6 +126,7 @@ class SitesFacilesBasePage(Page):
 
     search_fields = Page.search_fields + [
         index.SearchField("body"),
+        index.SearchField("hero"),
     ]
 
     # Export fields over the API

--- a/sites_conformes/core/tests/test_search.py
+++ b/sites_conformes/core/tests/test_search.py
@@ -29,6 +29,21 @@ class SearchResultsTestCase(WagtailPageTestCase):
                 body=body,
                 slug="public-content-page",
                 owner=self.admin,
+                hero=[
+                    (
+                        "hero_text_image",
+                        {
+                            "text_content": {
+                                "hero_title": "XylophoneHeroique",
+                                "hero_subtitle": RichText("<p>Hero subtitle</p>"),
+                                "position": "left",
+                            },
+                            "buttons": [],
+                            "image": {},
+                            "layout": {"top_margin": 5, "bottom_margin": 5, "background_color": ""},
+                        },
+                    )
+                ],
             )
         )
         self.public_content_page.save_revision().publish()
@@ -55,6 +70,13 @@ class SearchResultsTestCase(WagtailPageTestCase):
     def test_search_public_content_page_is_found(self):
         search_url = reverse("cms_search")
         response = self.client.get(f"{search_url}?q=Lorem")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Page de contenu publique")
+
+    def test_search_hero_text_is_found(self):
+        search_url = reverse("cms_search")
+        response = self.client.get(f"{search_url}?q=XylophoneHeroique")
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Page de contenu publique")


### PR DESCRIPTION
## 🎯 Objectif

Le hero n'est pas indexé, donc quand on cherche du texte présent dans le hero, le search ne le trouve pas.
On l'ajoute donc dans les search_fields.

