### PR TITLE
fine-tune gunicorn (preload, gthread, env-driven workers/threads/max-requests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,13 @@ WAGTAIL_PASSWORD_RESET_ENABLED=False
 # WAGTAIL_PASSWORD_RESET_ENABLED: set to true to be able to send the email
 # from the DEFAULT_FROM_EMAIL through the defined SMTP parameters
 
+# (Optional) Gunicorn tuning, see gunicorn.conf.py
+# GUNICORN_WORKERS=2
+# GUNICORN_THREADS=4
+# GUNICORN_TIMEOUT=120
+# GUNICORN_MAX_REQUESTS=10000
+# GUNICORN_MAX_REQUESTS_JITTER=2500
+
 # (Optional) Sentry settings - error monitoring
 # leave empty to disable Sentry. Get a DSN from your Sentry project settings.
 # Documentation : https://docs.sentry.io/platforms/python/integrations/django/

--- a/docs/deploiement/variables-environnement.md
+++ b/docs/deploiement/variables-environnement.md
@@ -160,6 +160,20 @@ surcharger pour les forks du projet.
 | `LATEST_RELEASE_URL` | Endpoint de l’API GitHub utilisé pour détecter la dernière version publiée. | API GitHub releases du dépôt | ⚪ |
 | `RELEASES_URL` | Page de releases liée depuis la notification de nouvelle version. | Page releases GitHub du dépôt | ⚪ |
 
+## Serveur applicatif (Gunicorn)
+
+Ces réglages sont lus par `gunicorn.conf.py` à la racine du dépôt, chargé
+automatiquement par Gunicorn quel que soit le mode de lancement (Procfile,
+Docker, systemd, `just run_gunicorn`).
+
+| Variable | Rôle | Défaut | Niveau |
+| --- | --- | --- | --- |
+| `GUNICORN_WORKERS` | Nombre de processus. À défaut, `WEB_CONCURRENCY` (défini par Scalingo) est utilisé. | `2` | ⚪ |
+| `GUNICORN_THREADS` | Nombre de threads par processus. | `4` | ⚪ |
+| `GUNICORN_TIMEOUT` | Délai (en secondes) avant qu’un processus bloqué soit redémarré. | `120` | ⚪ |
+| `GUNICORN_MAX_REQUESTS` | Nombre de requêtes traitées avant redémarrage d’un processus (limite les fuites mémoire). | `10000` | ⚪ |
+| `GUNICORN_MAX_REQUESTS_JITTER` | Aléa ajouté à `GUNICORN_MAX_REQUESTS` pour étaler les redémarrages. | `2500` | ⚪ |
+
 ## Supervision des erreurs (Sentry)
 
 | Variable | Rôle | Défaut | Niveau |

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,18 @@
+# Loaded automatically by gunicorn from the working directory (Procfile,
+# entrypoint.sh, `just run_gunicorn`, systemd). Every value can be overridden
+# with a GUNICORN_* environment variable.
+import os
+
+# Load the app in the master before forking: faster worker (re)start,
+# shared memory between workers.
+preload_app = True
+
+worker_class = "gthread"
+workers = int(os.environ.get("GUNICORN_WORKERS") or os.environ.get("WEB_CONCURRENCY") or 2)
+threads = int(os.environ.get("GUNICORN_THREADS", 4))
+timeout = int(os.environ.get("GUNICORN_TIMEOUT", 120))
+
+# Recycle workers periodically to contain memory leaks; the jitter spreads
+# restarts so workers don't all recycle at once.
+max_requests = int(os.environ.get("GUNICORN_MAX_REQUESTS", 10000))
+max_requests_jitter = int(os.environ.get("GUNICORN_MAX_REQUESTS_JITTER", 2500))


### PR DESCRIPTION
## 🎯 Objectif

Optimisation des performances de Gunicorn, portée depuis [incubateur-ademe/quefairedemesobjets#3373](https://github.com/incubateur-ademe/quefairedemesobjets/pull/3373) 

## 🔍 Implémentation

- Ajout de `gunicorn.conf.py` à la racine, chargé automatiquement par Gunicorn quel que soit le lanceur (Procfile, Docker, systemd, `just run_gunicorn`)
- `preload_app` : démarrage plus rapide des workers
- Worker `gthread` avec 4 threads, 2 workers par défaut (ou `WEB_CONCURRENCY` sur Scalingo)
- Recyclage des workers toutes les 10 000 requêtes (± 2 500) pour contenir les fuites mémoire

## ⚠️ Informations supplémentaires

Chaque valeur est surchargeable via `GUNICORN_WORKERS`, `GUNICORN_THREADS`, `GUNICORN_TIMEOUT`, `GUNICORN_MAX_REQUESTS`, `GUNICORN_MAX_REQUESTS_JITTER`. Documentées dans `docs/deploiement/variables-environnement.md` et `.env.example`.
